### PR TITLE
Add settings page and ghost length control

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import Login from './Components/Login';
 import List from './Components/List';
 import About from './Components/About'
 import MobileRedirect from './Components/MobileRedirect'
+import Settings from './Components/Settings'
 import { isMobile } from 'react-device-detect';
 import { supabase } from './supabaseClient';
 import {
@@ -54,6 +55,7 @@ function App() {
             <Route path="/login" element={<Login/>} ></Route>
             <Route path="/about" element={<About/>}/>
             <Route path="/mobile" element={<Navigate to="/login"/>}/>
+            <Route path="/settings" element={<Settings/>}/>
             <Route path="*" element={<Navigate to="/login"/>}/>
           </Routes>
         </Router>
@@ -65,6 +67,7 @@ function App() {
               <Route path="/editor" element={<Editor/>}/>
               <Route path="/edit/:postId" element={<Editor/>}/>
               <Route path="/view/:postId" element={<Editor readOnly/>}/>
+              <Route path="/settings" element={<Settings/>}/>
               <Route path="*" element={<Navigate to="/posts"/>}/>
             </Routes>
           </Router>

--- a/src/Components/Editor.js
+++ b/src/Components/Editor.js
@@ -142,6 +142,7 @@ function Editor(props) {
   // starts the ghost effect wherein the top block of text disappears periodically
   const startGhostEffect = () => {
     setTipsModalShown(true)
+    const gLen = parseInt(localStorage.getItem('GHOST_LENGTH_MS')) || 5000
     var gInt = setInterval(() => {
       if(document.querySelector('.parent').childElementCount > 1 && !document.querySelector('.parent').firstChild.classList.contains('fade')) {
         
@@ -166,7 +167,7 @@ function Editor(props) {
           })   
         })
       }
-    }, 5000)
+    }, gLen)
     // console.log(gInt)
     ghostInterval.current = gInt;
   }

--- a/src/Components/List.js
+++ b/src/Components/List.js
@@ -158,6 +158,9 @@ function List() {
                 }
               </VStack>
             </Center>
+            <Link to="/settings">
+              <Button style={{position: 'fixed', bottom: '2vh', left: '2vh'}} variant='ghost'>settings</Button>
+            </Link>
             <Button style={{position: 'fixed', bottom: '2vh', right: '2vh'}} variant='ghost' onClick={signOut}>close journal</Button>
           </Container>
         )

--- a/src/Components/Settings.js
+++ b/src/Components/Settings.js
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+import { Container, Center, VStack, Text, Button, HStack, Input, useNumberInput } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
+
+function Settings() {
+  const [ghostSeconds, setGhostSeconds] = useState(() => {
+    const val = localStorage.getItem('GHOST_LENGTH_MS');
+    return val ? parseInt(val)/1000 : 5;
+  });
+
+  const { getInputProps, getIncrementButtonProps, getDecrementButtonProps } = useNumberInput({
+    step: 1,
+    defaultValue: ghostSeconds,
+    min: 1,
+    max: 60,
+    precision: 0,
+    onChange: (valueString) => setGhostSeconds(parseInt(valueString))
+  });
+  const inc = getIncrementButtonProps();
+  const dec = getDecrementButtonProps();
+  const input = getInputProps();
+
+  useEffect(() => {
+    localStorage.setItem('GHOST_LENGTH_MS', ghostSeconds * 1000);
+  }, [ghostSeconds]);
+
+  return (
+    <Container maxW='sm' marginTop='25vh'>
+      <Center>
+        <VStack spacing={8}>
+          <Text>ghost effect interval (seconds)</Text>
+          <HStack maxW='200px'>
+            <Button variant='ghost' {...dec}>-</Button>
+            <Input readOnly variant='flushed' {...input} style={{textAlign: 'center'}} value={ghostSeconds}/>
+            <Button variant='ghost' {...inc}>+</Button>
+          </HStack>
+          <Link to='/posts'>
+            <Button variant='ghost'>done</Button>
+          </Link>
+        </VStack>
+      </Center>
+    </Container>
+  );
+}
+
+export default Settings;


### PR DESCRIPTION
## Summary
- create new `Settings` component to adjust ghost effect interval
- wire settings route into `App`
- link to settings from the posts list
- read ghost interval from local storage in the editor

## Testing
- `npm test --silent` *(fails: react-scripts not found)*